### PR TITLE
feat(frontend): add booking reservation form

### DIFF
--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -9,34 +9,290 @@
         <p class="card-subtitle">Enter booking information to predict cancellation likelihood</p>
     </div>
 
-    <!-- Form will be added in Branch 2 -->
-    <div class="placeholder">
-        <p>🌴 Booking form coming soon... 🌺</p>
-    </div>
+    <form id="booking-form" novalidate>
+        <div class="form-grid">
+            <!-- Guest Information Section -->
+            <div class="form-section">
+                <h3 class="form-section-title">
+                    <span>🌿</span> Guest Information
+                </h3>
 
-    <div class="card-actions">
-        <button type="button" class="btn btn-secondary" id="train-btn">
-            🔄 Train Model
-        </button>
-        <button type="button" class="btn btn-primary" id="predict-btn">
-            🔮 Predict Cancellation
-        </button>
-    </div>
+                <div class="form-group">
+                    <label class="form-label" for="number_of_adults">Number of Adults</label>
+                    <input
+                        type="number"
+                        id="number_of_adults"
+                        name="number of adults"
+                        class="form-input"
+                        value="2"
+                        min="1"
+                        max="10"
+                        required
+                    >
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="number_of_children">Number of Children</label>
+                    <input
+                        type="number"
+                        id="number_of_children"
+                        name="number of children"
+                        class="form-input"
+                        value="0"
+                        min="0"
+                        max="10"
+                    >
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label">Returning Guest</label>
+                    <div class="toggle-group">
+                        <button type="button" class="toggle-btn active" data-field="repeated" data-value="0">No</button>
+                        <button type="button" class="toggle-btn" data-field="repeated" data-value="1">Yes</button>
+                    </div>
+                    <input type="hidden" id="repeated" name="repeated" value="0">
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="p_c">Previous Cancellations</label>
+                    <input
+                        type="number"
+                        id="p_c"
+                        name="P-C"
+                        class="form-input"
+                        value="0"
+                        min="0"
+                    >
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="p_not_c">Previous Completed Stays</label>
+                    <input
+                        type="number"
+                        id="p_not_c"
+                        name="P-not-C"
+                        class="form-input"
+                        value="0"
+                        min="0"
+                    >
+                </div>
+            </div>
+
+            <!-- Stay Details Section -->
+            <div class="form-section">
+                <h3 class="form-section-title">
+                    <span>🌴</span> Stay Details
+                </h3>
+
+                <div class="form-group">
+                    <label class="form-label" for="weekend_nights">Weekend Nights</label>
+                    <input
+                        type="number"
+                        id="weekend_nights"
+                        name="number of weekend nights"
+                        class="form-input"
+                        value="1"
+                        min="0"
+                        max="14"
+                    >
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="week_nights">Weekday Nights</label>
+                    <input
+                        type="number"
+                        id="week_nights"
+                        name="number of week nights"
+                        class="form-input"
+                        value="2"
+                        min="0"
+                        max="30"
+                    >
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="lead_time">Days Until Arrival</label>
+                    <input
+                        type="number"
+                        id="lead_time"
+                        name="lead time"
+                        class="form-input"
+                        value="30"
+                        min="0"
+                        max="365"
+                    >
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="date_of_reservation">Reservation Date</label>
+                    <input
+                        type="date"
+                        id="date_of_reservation"
+                        name="date of reservation"
+                        class="form-input"
+                    >
+                </div>
+            </div>
+
+            <!-- Room & Services Section -->
+            <div class="form-section">
+                <h3 class="form-section-title">
+                    <span>🏝️</span> Room & Services
+                </h3>
+
+                <div class="form-group">
+                    <label class="form-label" for="room_type">Room Type</label>
+                    <select id="room_type" name="room type" class="form-select">
+                        <option value="Room_Type 1">Standard Room</option>
+                        <option value="Room_Type 2" selected>Deluxe Room</option>
+                        <option value="Room_Type 3">Suite</option>
+                        <option value="Room_Type 4">Premium Suite</option>
+                        <option value="Room_Type 5">Penthouse</option>
+                        <option value="Room_Type 6">Villa</option>
+                        <option value="Room_Type 7">Presidential</option>
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="meal_type">Meal Plan</label>
+                    <select id="meal_type" name="type of meal" class="form-select">
+                        <option value="Meal Plan 1" selected>Meal Plan 1</option>
+                        <option value="Meal Plan 2">Meal Plan 2</option>
+                        <option value="Meal Plan 3">Meal Plan 3</option>
+                        <option value="Not Selected">No Meal Plan</option>
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label">Parking Required</label>
+                    <div class="toggle-group">
+                        <button type="button" class="toggle-btn active" data-field="car_parking_space" data-value="0">No</button>
+                        <button type="button" class="toggle-btn" data-field="car_parking_space" data-value="1">Yes</button>
+                    </div>
+                    <input type="hidden" id="car_parking_space" name="car parking space" value="0">
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="special_requests">Special Requests</label>
+                    <input
+                        type="number"
+                        id="special_requests"
+                        name="special requests"
+                        class="form-input"
+                        value="0"
+                        min="0"
+                        max="5"
+                    >
+                </div>
+            </div>
+
+            <!-- Booking Info Section -->
+            <div class="form-section">
+                <h3 class="form-section-title">
+                    <span>🌺</span> Booking Info
+                </h3>
+
+                <div class="form-group">
+                    <label class="form-label" for="market_segment">Booking Channel</label>
+                    <select id="market_segment" name="market segment type" class="form-select">
+                        <option value="Online" selected>Online</option>
+                        <option value="Offline">Offline</option>
+                        <option value="Corporate">Corporate</option>
+                        <option value="Complementary">Complementary</option>
+                        <option value="Aviation">Aviation</option>
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="average_price">Nightly Rate ($)</label>
+                    <input
+                        type="number"
+                        id="average_price"
+                        name="average price"
+                        class="form-input"
+                        value="100.00"
+                        min="0"
+                        step="0.01"
+                    >
+                </div>
+            </div>
+        </div>
+
+        <div class="card-actions">
+            <button type="button" class="btn btn-secondary" id="train-btn">
+                🔄 Train Model
+            </button>
+            <button type="submit" class="btn btn-primary" id="predict-btn">
+                🔮 Predict Cancellation
+            </button>
+        </div>
+    </form>
 </section>
 
 <section class="card result-section" id="result-section" style="display: none;">
     <h2 class="card-title text-center">Cancellation Risk Assessment</h2>
     <p class="card-subtitle text-center">Based on historical patterns and guest profile</p>
     <div class="result-display" id="result-display">
-        <!-- Prediction result will be injected here -->
+        <!-- Prediction result will be injected here by JavaScript -->
     </div>
+    <p class="result-meta text-center" id="result-meta"></p>
 </section>
 
 <section class="card training-section" id="training-section" style="display: none;">
     <h2 class="card-title text-center">Training Progress</h2>
     <p class="card-subtitle text-center">Model retraining pipeline status</p>
     <div class="training-progress" id="training-progress">
-        <!-- Training progress will be injected here -->
+        <!-- Training progress will be injected here by JavaScript -->
     </div>
 </section>
+{% endblock %}
+
+{% block scripts %}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    // Set default date to today
+    const today = new Date().toISOString().split('T')[0];
+    document.getElementById('date_of_reservation').value = today;
+
+    // Toggle button functionality
+    document.querySelectorAll('.toggle-group').forEach(function(group) {
+        const buttons = group.querySelectorAll('.toggle-btn');
+
+        buttons.forEach(function(btn) {
+            btn.addEventListener('click', function() {
+                const field = this.dataset.field;
+                const value = this.dataset.value;
+                const hiddenInput = document.getElementById(field);
+
+                // Update active state
+                buttons.forEach(function(b) {
+                    b.classList.remove('active');
+                });
+                this.classList.add('active');
+
+                // Update hidden input value
+                if (hiddenInput) {
+                    hiddenInput.value = value;
+                }
+            });
+        });
+    });
+
+    // Form validation feedback
+    const form = document.getElementById('booking-form');
+    const inputs = form.querySelectorAll('.form-input, .form-select');
+
+    inputs.forEach(function(input) {
+        input.addEventListener('invalid', function() {
+            this.classList.add('invalid');
+        });
+
+        input.addEventListener('input', function() {
+            if (this.validity.valid) {
+                this.classList.remove('invalid');
+            }
+        });
+    });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
Implements the complete reservation form matching the FastAPI /predict/ endpoint schema.

Form fields:
- Guest info: adults, children, returning guests, previous cancellations/stays
- Stay details: weekend/weekday nights, lead time, reservation date
- Room & services: room type, meal plan, parking, special requests
- Booking info: channel, nightly rate

Design choices:
- Form name attributes use original CSV column names for API compatibility
- Toggle buttons with hidden inputs for boolean fields (returning guest, parking)
- HTML5 validation via min/max/required attributes
- Default values pre-populated for a typical booking scenario
- Date defaults to today via JavaScript fixed frontend indentation on docker-compose.yml